### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,4 +1,6 @@
 name: github-pages-deploy
+permissions:
+  contents: write
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Ivan951236/ivans-font-buffet-docs/security/code-scanning/2](https://github.com/Ivan951236/ivans-font-buffet-docs/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow. This block should be placed at the root level (recommended), or inside the relevant job, to restrict the GITHUB_TOKEN to only the required scopes. For a typical GitHub Pages deployment, you'll need `contents: write` (to push to branches like `gh-pages`), and usually nothing else. Add the following block after the workflow `name:` (line 1), and before `env:`/`jobs:`. No special methods or imports are needed; just a simple YAML configuration edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
