### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -1,4 +1,6 @@
 name: pull-request-check
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Ivan951236/ivans-font-buffet-docs/security/code-scanning/1](https://github.com/Ivan951236/ivans-font-buffet-docs/security/code-scanning/1)

The best way to resolve this problem is to explicitly specify a minimal `permissions` block in the workflow. This is achieved by adding:

```yaml
permissions:
  contents: read
```

You can add this at the root of the workflow (applies to all jobs), or to the specific job(s) if you want different permissions per job. In this case, a root-level setting is adequate and clearer. The change should be made at the top level, after the `name` or `on` block, and before the `jobs` definition. No new methods, imports, or non-YAML dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
